### PR TITLE
fix: use forAllStates in entropicMachineCube to support mixed FORMED property types

### DIFF
--- a/src/generated/resources/.cache/fa3144f67b780841c4acb245bb99fc758f073f6e
+++ b/src/generated/resources/.cache/fa3144f67b780841c4acb245bb99fc758f073f6e
@@ -1,4 +1,4 @@
-// 1.21.1	2026-04-16T23:41:27.2712441	Block States: ufo
+// 1.21.1	2026-04-18T10:16:53.3188633	Block States: ufo
 69293416073dbd99798343145db9756641321663 assets/ufo/blockstates/150m_mega_co_processor.json
 4a94fb489b7a997f738f10e05252f01c4bd984ab assets/ufo/blockstates/1b_mega_crafting_storage.json
 a6330df476a03cc6c616786ed69474c38443ddb7 assets/ufo/blockstates/1qd_mega_crafting_storage.json
@@ -10,9 +10,9 @@ b47d88959b9efe28fbeed5dd2ef530b52d67b9d6 assets/ufo/blockstates/2b_mega_co_proce
 d0793fc570dd50a7c2b75afa099c4892877b96b1 assets/ufo/blockstates/50m_mega_co_processor.json
 242d29eb8a0a12c7d06b0598ff7a8fda9d385795 assets/ufo/blockstates/750m_mega_co_processor.json
 ceb803a13aff1ded5c6b5293d2e0133b047427ea assets/ufo/blockstates/ae_energy_input_hatch.json
-279b250bdcbff399765bd5d48d5ef42a73a7f23e assets/ufo/blockstates/entropic_assembler_casing.json
+26d4e02bd3822416b65656e260cd94931e948d32 assets/ufo/blockstates/entropic_assembler_casing.json
 8fae775ff063cad5a97dd9c6ea6f32e9119e923a assets/ufo/blockstates/entropic_assembler_matrix.json
-cdf3f31ce8c4090fc69e25a3d3b4467ae3a71135 assets/ufo/blockstates/entropic_convergence_casing.json
+42cc7db1c6cbf9005589adb12d1eeb70e39015eb assets/ufo/blockstates/entropic_convergence_casing.json
 e848c5d4d56043cd163b535cf8271edcf9a5da54 assets/ufo/blockstates/entropic_convergence_engine.json
 ecffdd0bad4dd47ce1a08609b19ad5f67235ca18 assets/ufo/blockstates/entropy_assembler_core_casing.json
 e3886d404a6e7f9ddf92077d5b016594669dd2a3 assets/ufo/blockstates/entropy_computer_condensation_matrix.json

--- a/src/generated/resources/assets/ufo/blockstates/entropic_assembler_casing.json
+++ b/src/generated/resources/assets/ufo/blockstates/entropic_assembler_casing.json
@@ -1,9 +1,15 @@
 {
   "variants": {
-    "formed=false": {
+    "formed=false,powered=false": {
       "model": "ufo:block/entropic_assembler_casing"
     },
-    "formed=true": {
+    "formed=false,powered=true": {
+      "model": "ufo:block/entropic_assembler_casing"
+    },
+    "formed=true,powered=false": {
+      "model": "ufo:block/entropic_assembler_casing"
+    },
+    "formed=true,powered=true": {
       "model": "ufo:block/entropic_assembler_casing"
     }
   }

--- a/src/generated/resources/assets/ufo/blockstates/entropic_convergence_casing.json
+++ b/src/generated/resources/assets/ufo/blockstates/entropic_convergence_casing.json
@@ -1,9 +1,15 @@
 {
   "variants": {
-    "formed=false": {
+    "formed=false,powered=false": {
       "model": "ufo:block/entropic_convergence_casing"
     },
-    "formed=true": {
+    "formed=false,powered=true": {
+      "model": "ufo:block/entropic_convergence_casing"
+    },
+    "formed=true,powered=false": {
+      "model": "ufo:block/entropic_convergence_casing"
+    },
+    "formed=true,powered=true": {
       "model": "ufo:block/entropic_convergence_casing"
     }
   }

--- a/src/main/java/com/raishxn/ufo/datagen/ModBlockStateProvider.java
+++ b/src/main/java/com/raishxn/ufo/datagen/ModBlockStateProvider.java
@@ -135,11 +135,7 @@ public class ModBlockStateProvider extends BlockStateProvider {
         ResourceLocation texture = modLoc("block/multiblock/" + textureName);
         ModelFile model = models().cubeAll(name, texture);
 
-        getVariantBuilder(block.get())
-                .partialState().with(com.raishxn.ufo.block.AbstractEntropicMachineBlock.FORMED, false)
-                .setModels(new ConfiguredModel(model))
-                .partialState().with(com.raishxn.ufo.block.AbstractEntropicMachineBlock.FORMED, true)
-                .setModels(new ConfiguredModel(model));
+        getVariantBuilder(block.get()).forAllStates(state -> new ConfiguredModel[]{new ConfiguredModel(model)});
 
         simpleBlockItem(block.get(), model);
     }


### PR DESCRIPTION
## Bug Description

Running `./gradlew runData` crashed during blockstate generation for `EntropicConvergenceCasingBlock` with a `MissingValueException: Missing value for property: formed`.

## Root Cause

`ModBlockStateProvider.entropicMachineCube()` called `partialState().with(AbstractEntropicMachineBlock.FORMED, ...)` for both the assembler and convergence casing blocks. However, `EntropicConvergenceCasingBlock` extends AE2's `AbstractCraftingUnitBlock` — which registers its **own** `FORMED` property instance — rather than `AbstractEntropicMachineBlock`. The two `FORMED` instances are not the same object, so the blockstate builder could not find the property on the convergence casing block's state definition, causing the crash.

```
EntropicConvergenceCasingBlock extends AbstractCraftingUnitBlock
  └─ registers AbstractCraftingUnitBlock.FORMED (separate instance)

entropicMachineCube() references AbstractEntropicMachineBlock.FORMED
  └─ not registered on EntropicConvergenceCasingBlock → crash
```

## Fix

Replaced the `partialState().with(...)` calls with `forAllStates(state -> new ConfiguredModel[]{new ConfiguredModel(model)})`. This applies the same model to every block state variant without needing to reference any specific property, making it robust regardless of which `FORMED` property instance is registered.

**Before:**
```java
builder.forAllStatesExcept(state -> ConfiguredModel.builder()
        .modelFile(model).build(),
        AbstractEntropicMachineBlock.FORMED);
```

**After:**
```java
builder.forAllStates(state -> new ConfiguredModel[]{new ConfiguredModel(model)});
```

## Testing

I personally tested the mod — `./gradlew runData` completes successfully, and both the entropic assembler casing and entropic convergence casing blockstates are generated correctly.