### PR TITLE
fix: add bootstrap DMA recipes to break pre-QMF progression deadlocks

### DIFF
--- a/src/generated/resources/.cache/9fb1092f32d4fcbf9e061ffd718d4ec689c6c95e
+++ b/src/generated/resources/.cache/9fb1092f32d4fcbf9e061ffd718d4ec689c6c95e
@@ -1,4 +1,4 @@
-// 1.21.1	2026-04-16T23:55:31.3238849	Recipes
+// 1.21.1	2026-04-18T18:28:40.893469692	Recipes
 623466a712bf2b54aad620b471840892932161d4 data/ufo/advancement/recipes/misc/ae_energy_input_hatch.json
 a25a6bd915843952e3b74014247693fdda691447 data/ufo/advancement/recipes/misc/bismuth.json
 a1f0792f9fc46d8107fb77d82b3129e97aec9e05 data/ufo/advancement/recipes/misc/coprocessor_150m.json
@@ -107,19 +107,22 @@ c752eeae581af2aeaaab5771eafc4b84a0f05bce data/ufo/recipe/dma/gelid_cryotheum_boo
 39b42783751d91192021346543bb0e8d25e44511 data/ufo/recipe/dma/liquid_starlight.json
 f3f84667f1b49ad3cb7fa086b6bb460fb8e405eb data/ufo/recipe/dma/matterflow_catalyst_t1.json
 2b710f4210d9387e73745cd7f89c3aed83c9e1b5 data/ufo/recipe/dma/matterflow_catalyst_t2.json
-c32f91e06d333bb3520570c09b168e1cc5d1d2ec data/ufo/recipe/dma/neutronium_sphere.json
 19f9a778df142d9a95625f9af2deae4ac9314b15 data/ufo/recipe/dma/neutron_star_dust.json
 f6f2ecb219f4aaf2dee285c82b14cac755013209 data/ufo/recipe/dma/neutron_star_fluid.json
 30058a77669ab3622e4df9c0938194fc4f9241f4 data/ufo/recipe/dma/neutron_star_fragment_rod.json
 58dae6ff88abd8ddbfa3871080895e1614551c3f data/ufo/recipe/dma/neutron_star_matter.json
+c32f91e06d333bb3520570c09b168e1cc5d1d2ec data/ufo/recipe/dma/neutronium_sphere.json
 05b452dfc93724293093c35581def4d3ffd22f91 data/ufo/recipe/dma/nuclear_star.json
 63f5b35aa05160cbf86cb14ced0943c7d1c86260 data/ufo/recipe/dma/overflux_catalyst_t1.json
 24b5445c2128c8ecd3cd200a089dd6af45719f07 data/ufo/recipe/dma/overflux_catalyst_t2.json
 f63b607af28ddf10aff732d3715a5b1406e06f90 data/ufo/recipe/dma/primordial_matter_liquid.json
 aabc03e825937b0e1192d034fefc619b32d8da86 data/ufo/recipe/dma/printed_dimensional_processor.json
 f86ecbb853ee1bcc6e5d018e02c1ff5cc5b97cb9 data/ufo/recipe/dma/proto_matter.json
+4abe5eae71ed6c4f3c7efa7d0c41363ef1d4e6ef data/ufo/recipe/dma/proto_matter_bootstrap.json
 b94e87211b57660f51928eac239c7da4ec01850d data/ufo/recipe/dma/pulsar_dust.json
+22901219d988671f863a487fc833da35f4f18751 data/ufo/recipe/dma/pulsar_fluid.json
 961e949e9e32a76371405378a9f4dcaab835e76e data/ufo/recipe/dma/pulsar_matter.json
+861373e2f0e1efced51dc4a90bb48f3e8a526c6a data/ufo/recipe/dma/quantum_anomaly.json
 065d453b75f36c1e552f0182ffa24f42e8e7c523 data/ufo/recipe/dma/quantum_catalyst_t1.json
 7e8a1b005c7379ebdd51afb20b5bba1c4212ddea data/ufo/recipe/dma/quantum_catalyst_t2.json
 bc20feaf24272e8ad6e8e6b471c3fc0c850327cb data/ufo/recipe/dma/raw_star_matter_plasma.json
@@ -237,17 +240,20 @@ f77bfb17d98acd04e3322387a5e956a287646710 data/ufo/recipe/universal/qmf/bulk/ingo
 72c3edbadef814b6795dce4f6579e053fb21234b data/ufo/recipe/universal/qmf/bulk/liquid_starlight.json
 8caceb556aa72989c0adec439c9a789b43c3b8e0 data/ufo/recipe/universal/qmf/bulk/matterflow_catalyst_t1.json
 f495bd0e29615fc15fbbd4d2243ae39b97ba828b data/ufo/recipe/universal/qmf/bulk/matterflow_catalyst_t2.json
-0fac8bd806fdf740a858b380adaf2af879aceba3 data/ufo/recipe/universal/qmf/bulk/neutronium_sphere.json
 b547c459e32c8ef115ccf3f2545df3cc67674212 data/ufo/recipe/universal/qmf/bulk/neutron_star_dust.json
 2f7677d70714564e612e69f11f6f214f24ddccc1 data/ufo/recipe/universal/qmf/bulk/neutron_star_fluid.json
 cf683f3b646dfc4eec857f1b7dec8dd728d59ec2 data/ufo/recipe/universal/qmf/bulk/neutron_star_fragment_rod.json
+0fac8bd806fdf740a858b380adaf2af879aceba3 data/ufo/recipe/universal/qmf/bulk/neutronium_sphere.json
 55b068ac567955809bccdbe443df88aa8d25b71e data/ufo/recipe/universal/qmf/bulk/nuclear_star.json
 a55bef7ce27c1ecc9739044707fba672987437da data/ufo/recipe/universal/qmf/bulk/overflux_catalyst_t1.json
 60d197acb3a47d2da86b714c2099da20042b1ebe data/ufo/recipe/universal/qmf/bulk/overflux_catalyst_t2.json
 e0acf54b92f65f9cc78a2b4239bd93e4d18c47a8 data/ufo/recipe/universal/qmf/bulk/primordial_matter_liquid.json
 7307d8a4d1ac872c8269de579f59ead2c8023f06 data/ufo/recipe/universal/qmf/bulk/printed_dimensional_processor.json
 45fe466a8bcf25ba884dd90ca20e3112a7776cc0 data/ufo/recipe/universal/qmf/bulk/proto_matter.json
+479e810c880311a2fb6222397c609ea31747bf0d data/ufo/recipe/universal/qmf/bulk/proto_matter_bootstrap.json
 d23b6a92d3b9ba8e5393b01aef7a3621bb2f0b14 data/ufo/recipe/universal/qmf/bulk/pulsar_dust.json
+75404895b9dad05aac6aae314b743db31153446e data/ufo/recipe/universal/qmf/bulk/pulsar_fluid.json
+38c0ecc54eb19670c82451d7245d3ee105c416a5 data/ufo/recipe/universal/qmf/bulk/quantum_anomaly.json
 39a74b2a0895700b7428e1efd91cd39f438a8e27 data/ufo/recipe/universal/qmf/bulk/quantum_catalyst_t1.json
 d91b400374912e967bd0a0d167ae410b1abb7d66 data/ufo/recipe/universal/qmf/bulk/quantum_catalyst_t2.json
 4c10f0c7ce9d1401ee9aaeb4ff34ce059efaa18f data/ufo/recipe/universal/qmf/bulk/raw_star_matter_plasma.json

--- a/src/generated/resources/data/ufo/recipe/dma/proto_matter_bootstrap.json
+++ b/src/generated/resources/data/ufo/recipe/dma/proto_matter_bootstrap.json
@@ -1,0 +1,47 @@
+{
+  "type": "ufo:dimensional_assembly",
+  "energy": 10000000,
+  "fluid_inputs": [
+    {
+      "amount": 8000,
+      "ingredient": {
+        "fluid": "ufo:uu_matter"
+      }
+    }
+  ],
+  "fluid_outputs": [],
+  "item_inputs": [
+    {
+      "amount": 16,
+      "ingredient": {
+        "item": "ufo:neutron_star_fragment_ingot"
+      }
+    },
+    {
+      "amount": 8,
+      "ingredient": {
+        "item": "ufo:white_dwarf_fragment_ingot"
+      }
+    },
+    {
+      "amount": 8,
+      "ingredient": {
+        "item": "ufo:obsidian_matrix"
+      }
+    },
+    {
+      "amount": 8,
+      "ingredient": {
+        "item": "ufo:dimensional_processor"
+      }
+    }
+  ],
+  "item_outputs": [
+    {
+      "#": 1,
+      "#t": "ae2:i",
+      "id": "ufo:proto_matter"
+    }
+  ],
+  "time": 1200
+}

--- a/src/generated/resources/data/ufo/recipe/dma/pulsar_fluid.json
+++ b/src/generated/resources/data/ufo/recipe/dma/pulsar_fluid.json
@@ -1,0 +1,34 @@
+{
+  "type": "ufo:dimensional_assembly",
+  "energy": 80000,
+  "fluid_inputs": [
+    {
+      "amount": 200,
+      "ingredient": {
+        "fluid": "ufo:source_liquid_starlight_fluid"
+      }
+    }
+  ],
+  "fluid_outputs": [
+    {
+      "#": 1000,
+      "#t": "ae2:f",
+      "id": "ufo:source_pulsar_fragment_fluid"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 4,
+      "ingredient": {
+        "item": "ufo:pulsar_fragment_ingot"
+      }
+    },
+    {
+      "ingredient": {
+        "item": "minecraft:blue_ice"
+      }
+    }
+  ],
+  "item_outputs": [],
+  "time": 200
+}

--- a/src/generated/resources/data/ufo/recipe/dma/quantum_anomaly.json
+++ b/src/generated/resources/data/ufo/recipe/dma/quantum_anomaly.json
@@ -1,0 +1,41 @@
+{
+  "type": "ufo:dimensional_assembly",
+  "energy": 4000000,
+  "fluid_inputs": [
+    {
+      "amount": 2000,
+      "ingredient": {
+        "fluid": "ufo:source_pulsar_fragment_fluid"
+      }
+    }
+  ],
+  "fluid_outputs": [],
+  "item_inputs": [
+    {
+      "amount": 16,
+      "ingredient": {
+        "item": "ufo:pulsar_fragment_dust"
+      }
+    },
+    {
+      "amount": 2,
+      "ingredient": {
+        "item": "ufo:obsidian_matrix"
+      }
+    },
+    {
+      "amount": 2,
+      "ingredient": {
+        "item": "ufo:dimensional_processor"
+      }
+    }
+  ],
+  "item_outputs": [
+    {
+      "#": 1,
+      "#t": "ae2:i",
+      "id": "ufo:quantum_anomaly"
+    }
+  ],
+  "time": 600
+}

--- a/src/generated/resources/data/ufo/recipe/universal/qmf/bulk/proto_matter_bootstrap.json
+++ b/src/generated/resources/data/ufo/recipe/universal/qmf/bulk/proto_matter_bootstrap.json
@@ -1,0 +1,46 @@
+{
+  "type": "ufo:universal_multiblock",
+  "energy": 640000000,
+  "fluid_inputs": [
+    {
+      "amount": 512000,
+      "fluid": {
+        "amount": 1,
+        "id": "ufo:uu_matter"
+      }
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1024,
+      "ingredient": {
+        "item": "ufo:neutron_star_fragment_ingot"
+      }
+    },
+    {
+      "amount": 512,
+      "ingredient": {
+        "item": "ufo:white_dwarf_fragment_ingot"
+      }
+    },
+    {
+      "amount": 512,
+      "ingredient": {
+        "item": "ufo:obsidian_matrix"
+      }
+    },
+    {
+      "amount": 512,
+      "ingredient": {
+        "item": "ufo:dimensional_processor"
+      }
+    }
+  ],
+  "item_output": {
+    "count": 64,
+    "id": "ufo:proto_matter"
+  },
+  "machine": "qmf",
+  "recipe_name": "universal/qmf/bulk/proto_matter_bootstrap",
+  "time": 1200
+}

--- a/src/generated/resources/data/ufo/recipe/universal/qmf/bulk/pulsar_fluid.json
+++ b/src/generated/resources/data/ufo/recipe/universal/qmf/bulk/pulsar_fluid.json
@@ -1,0 +1,35 @@
+{
+  "type": "ufo:universal_multiblock",
+  "energy": 5120000,
+  "fluid_inputs": [
+    {
+      "amount": 12800,
+      "fluid": {
+        "amount": 1,
+        "id": "ufo:source_liquid_starlight_fluid"
+      }
+    }
+  ],
+  "fluid_output": {
+    "amount": 1,
+    "id": "ufo:source_pulsar_fragment_fluid"
+  },
+  "fluid_output_amount": 64000,
+  "item_inputs": [
+    {
+      "amount": 256,
+      "ingredient": {
+        "item": "ufo:pulsar_fragment_ingot"
+      }
+    },
+    {
+      "amount": 64,
+      "ingredient": {
+        "item": "minecraft:blue_ice"
+      }
+    }
+  ],
+  "machine": "qmf",
+  "recipe_name": "universal/qmf/bulk/pulsar_fluid",
+  "time": 200
+}

--- a/src/generated/resources/data/ufo/recipe/universal/qmf/bulk/quantum_anomaly.json
+++ b/src/generated/resources/data/ufo/recipe/universal/qmf/bulk/quantum_anomaly.json
@@ -1,0 +1,40 @@
+{
+  "type": "ufo:universal_multiblock",
+  "energy": 256000000,
+  "fluid_inputs": [
+    {
+      "amount": 128000,
+      "fluid": {
+        "amount": 1,
+        "id": "ufo:source_pulsar_fragment_fluid"
+      }
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1024,
+      "ingredient": {
+        "item": "ufo:pulsar_fragment_dust"
+      }
+    },
+    {
+      "amount": 128,
+      "ingredient": {
+        "item": "ufo:obsidian_matrix"
+      }
+    },
+    {
+      "amount": 128,
+      "ingredient": {
+        "item": "ufo:dimensional_processor"
+      }
+    }
+  ],
+  "item_output": {
+    "count": 64,
+    "id": "ufo:quantum_anomaly"
+  },
+  "machine": "qmf",
+  "recipe_name": "universal/qmf/bulk/quantum_anomaly",
+  "time": 600
+}

--- a/src/main/java/com/raishxn/ufo/datagen/ModRecipeProvider.java
+++ b/src/main/java/com/raishxn/ufo/datagen/ModRecipeProvider.java
@@ -183,6 +183,7 @@ public class ModRecipeProvider extends RecipeProvider {
         DMARecipeBuilder.create("dma/white_dwarf_fluid").outputFluid(ModFluids.SOURCE_WHITE_DWARF_FRAGMENT_FLUID.get(), 1000, 1.0F).inputItem(ModItems.WHITE_DWARF_FRAGMENT_INGOT.get(), 4).inputItem(Items.BLUE_ICE).inputFluid(ModFluids.SOURCE_LIQUID_STARLIGHT_FLUID.get(), 200).energy(40000).time(120).save(c);
         DMARecipeBuilder.create("dma/neutron_star_dust").output(ModItems.NEUTRON_STAR_FRAGMENT_DUST.get()).inputItem(ModItems.NEUTRON_STAR_FRAGMENT_INGOT.get()).inputFluid(ModFluids.SOURCE_LIQUID_STARLIGHT_FLUID.get(), 20).energy(15000).time(80).save(c);
         DMARecipeBuilder.create("dma/neutron_star_fluid").outputFluid(ModFluids.SOURCE_NEUTRON_STAR_FRAGMENT_FLUID.get(), 1000, 1.0F).inputItem(ModItems.NEUTRON_STAR_FRAGMENT_INGOT.get(), 4).inputItem(Items.BLUE_ICE).inputFluid(ModFluids.SOURCE_LIQUID_STARLIGHT_FLUID.get(), 200).energy(60000).time(150).save(c);
+        DMARecipeBuilder.create("dma/pulsar_fluid").outputFluid(ModFluids.SOURCE_PULSAR_FRAGMENT_FLUID.get(), 1000, 1.0F).inputItem(ModItems.PULSAR_FRAGMENT_INGOT.get(), 4).inputItem(Items.BLUE_ICE).inputFluid(ModFluids.SOURCE_LIQUID_STARLIGHT_FLUID.get(), 200).energy(80000).time(200).save(c);
         DMARecipeBuilder.create("dma/pulsar_dust").output(ModItems.PULSAR_FRAGMENT_DUST.get()).inputItem(ModItems.PULSAR_FRAGMENT_INGOT.get()).inputItem(AEBlocks.TINY_TNT).inputFluid(ModFluids.SOURCE_LIQUID_STARLIGHT_FLUID.get(), 20).energy(20000).time(100).save(c);
         DMARecipeBuilder.create("dma/dust_blizz").output(ModItems.DUST_BLIZZ.get(), 4).inputItem(Items.SNOWBALL, 4).inputItem(Items.REDSTONE).inputFluid(ModFluids.SOURCE_LIQUID_STARLIGHT_FLUID.get(), 50).energy(20000).time(80).save(c);
         DMARecipeBuilder.create("dma/dust_cryotheum").output(ModItems.DUST_CRYOTHEUM.get(), 2).inputItem(ModItems.DUST_BLIZZ.get(), 2).inputItem(Items.REDSTONE, 2).inputItem(Items.SNOWBALL).inputFluid(Fluids.WATER, 100).energy(40000).time(100).save(c);
@@ -240,6 +241,15 @@ public class ModRecipeProvider extends RecipeProvider {
     }
 
     private void buildMatterProgression(RecipeOutput c) {
+        DMARecipeBuilder.create("dma/quantum_anomaly")
+                .output(ModItems.QUANTUM_ANOMALY.get())
+                .inputItem(ModItems.PULSAR_FRAGMENT_DUST.get(), 16)
+                .inputItem(ModItems.OBSIDIAN_MATRIX.get(), 2)
+                .inputItem(ModItems.DIMENSIONAL_PROCESSOR.get(), 2)
+                .inputFluid(ModFluids.SOURCE_PULSAR_FRAGMENT_FLUID.get(), 2000)
+                .energy(4000000)
+                .time(600)
+                .save(c);
         DMARecipeBuilder.create("dma/neutronium_sphere").output(ModItems.NEUTRONIUM_SPHERE.get()).inputItem(ModItems.NEUTRON_STAR_FRAGMENT_INGOT.get(), 9).inputFluid(ModFluids.SOURCE_UU_AMPLIFIER_FLUID.get(), 500).energy(1000000).time(600).save(c);
         DMARecipeBuilder.create("dma/enriched_neutronium_sphere")
                 .output(ModItems.ENRICHED_NEUTRONIUM_SPHERE.get())
@@ -249,6 +259,16 @@ public class ModRecipeProvider extends RecipeProvider {
                 .inputFluid(ModFluids.SOURCE_PRIMORDIAL_MATTER_FLUID.get(), 16000)
                 .energy(6000000)
                 .time(7200)
+                .save(c);
+        DMARecipeBuilder.create("dma/proto_matter_bootstrap")
+                .output(ModItems.PROTO_MATTER.get())
+                .inputItem(ModItems.NEUTRON_STAR_FRAGMENT_INGOT.get(), 16)
+                .inputItem(ModItems.WHITE_DWARF_FRAGMENT_INGOT.get(), 8)
+                .inputItem(ModItems.OBSIDIAN_MATRIX.get(), 8)
+                .inputItem(ModItems.DIMENSIONAL_PROCESSOR.get(), 8)
+                .inputFluid(ModFluids.SOURCE_UU_MATTER_FLUID.get(), 8000)
+                .energy(10000000)
+                .time(1200)
                 .save(c);
         DMARecipeBuilder.create("dma/proto_matter")
                 .output(ModItems.PROTO_MATTER.get())


### PR DESCRIPTION
## Bug Description — Three Pre-QMF Progression Deadlocks

Version 2.0.0 introduced three circular/missing-source deadlocks that make it **impossible to progress past a certain point** without the Quantum Matter Fabricator already built — but building the QMF itself requires the items locked behind those deadlocks.

---

### Deadlock A — Quantum Anomaly Circular Dependency

**Cause:**  
The only recipe producing `Quantum Anomaly` was `universal/qmf/quantum_anomaly_batch` (QMF-locked). But `Quantum Anomaly` is required to craft the QMF itself (via Enriched Neutronium Sphere → Primordial Matter Flow). Result: **the QMF can never be built**.

```
Build QMF → needs Quantum Anomaly → only made by QMF → deadlock
```

**Fix:** Added `dma/quantum_anomaly` — a DMA bootstrap recipe using pre-QMF materials (Pulsar Fragment Dust, Obsidian Matrix, Dimensional Processor, Pulsar Fragment Fluid). Cost is intentionally ~2× higher per unit than the QMF batch.

```json
// data/ufo/recipe/dma/quantum_anomaly.json
{
  "type": "ufo:dimensional_assembly",
  "energy": 4000000,
  "time": 600,
  "item_inputs": [
    { "amount": 16, "ingredient": { "item": "ufo:pulsar_fragment_dust" } },
    { "amount": 2,  "ingredient": { "item": "ufo:obsidian_matrix" } },
    { "amount": 2,  "ingredient": { "item": "ufo:dimensional_processor" } }
  ],
  "fluid_inputs": [
    { "amount": 2000, "ingredient": { "fluid": "ufo:source_pulsar_fragment_fluid" } }
  ],
  "item_outputs": [{ "id": "ufo:quantum_anomaly" }]
}
```

---

### Deadlock B — Proto Matter Circular Dependency

**Cause:**  
`dma/proto_matter` required `Enriched Neutronium Sphere` (ENS), but ENS needed the Proto Matter Flow recipe (`PMF`), which needed `Quantum Anomaly` (locked — see above) and `Raw Stellar Matter Particles` (RSMP). RSMP required `Corporeal Matter`, which required `Proto Matter`. Result: **Proto Matter can never be bootstrapped**.

```
Proto Matter → ENS → PMF → RSMP → Corporeal Matter → Proto Matter → deadlock
```

**Fix:** Added `dma/proto_matter_bootstrap` — a DMA bootstrap recipe using raw stellar materials (NSF Ingot, WD Ingot, Obsidian Matrix, Dimensional Processor, UU Matter). Cost is 2× the normal 5M EU recipe.

```json
// data/ufo/recipe/dma/proto_matter_bootstrap.json
{
  "type": "ufo:dimensional_assembly",
  "energy": 10000000,
  "time": 1200,
  "item_inputs": [
    { "amount": 16, "ingredient": { "item": "ufo:neutron_star_fragment_ingot" } },
    { "amount": 8,  "ingredient": { "item": "ufo:white_dwarf_fragment_ingot" } },
    { "amount": 8,  "ingredient": { "item": "ufo:obsidian_matrix" } },
    { "amount": 8,  "ingredient": { "item": "ufo:dimensional_processor" } }
  ],
  "fluid_inputs": [
    { "amount": 8000, "ingredient": { "fluid": "ufo:uu_matter" } }
  ],
  "item_outputs": [{ "id": "ufo:proto_matter" }]
}
```

---

### Deadlock C — Pulsar Fragment Fluid Missing DMA Recipe

**Cause:**  
`dma/quantum_anomaly` (fix for Deadlock A) requires 2000 mB of Pulsar Fragment Fluid. However, there was **no DMA recipe to produce Pulsar Fragment Fluid** — only `universal/qmf/pulsar_fluid` (QMF-locked) and Stellar Simulation (post-QMF). White Dwarf and Neutron Star fluids both had DMA fluid recipes; Pulsar did not. The asymmetry made Deadlock A's fix unreachable.

**Fix:** Added `dma/pulsar_fluid` — mirrors the WD/NS fluid pattern (80k EU, progressive with WD=40k/NS=60k/Pulsar=80k).

```json
// data/ufo/recipe/dma/pulsar_fluid.json
{
  "type": "ufo:dimensional_assembly",
  "energy": 80000,
  "time": 200,
  "item_inputs": [
    { "amount": 4, "ingredient": { "item": "ufo:pulsar_fragment_ingot" } },
    { "ingredient": { "item": "minecraft:blue_ice" } }
  ],
  "fluid_inputs": [
    { "amount": 200, "ingredient": { "fluid": "ufo:source_liquid_starlight_fluid" } }
  ],
  "fluid_outputs": [{ "id": "ufo:source_pulsar_fragment_fluid", "amount": 1000 }]
}
```

---

## Testing

I personally tested the mod to verify that all three recipes function correctly without deadlock — the full progression from raw stellar materials through QMF construction is now achievable in a survival world.