### PR TITLE
fix: avoid ExpandedAE crafting CPU mixin conflict

### DIFF
--- a/src/main/java/com/raishxn/ufo/mixin/MixinCraftingCPUCluster.java
+++ b/src/main/java/com/raishxn/ufo/mixin/MixinCraftingCPUCluster.java
@@ -1,52 +1,53 @@
 package com.raishxn.ufo.mixin;
 
 import appeng.blockentity.crafting.CraftingBlockEntity;
-import appeng.blockentity.crafting.CraftingMonitorBlockEntity;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
-import appeng.me.helpers.MachineSource;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 
 @Mixin(value = CraftingCPUCluster.class, priority = 3000, remap = false)
 public abstract class MixinCraftingCPUCluster {
-    @Shadow private MachineSource machineSrc;
     @Shadow private List<CraftingBlockEntity> blockEntities;
-    @Shadow private List<CraftingMonitorBlockEntity> status;
-    @Shadow private long storage;
     @Shadow private int accelerator;
 
     /**
-     * @author Codex
-     * @reason Remove AE2's hard 16-threads-per-block restriction while preserving
-     * the real co-processor values from UFO tiers and saturating the total at
-     * Integer.MAX_VALUE to avoid overflow when CPUs become extremely large.
+     * Preserve AE2's original method shape so other add-ons can still inject
+     * into addBlockEntity, but bypass the hard per-block 16 thread exception
+     * for UFO's larger crafting units.
      */
-    @Overwrite
-    void addBlockEntity(CraftingBlockEntity te) {
-        if (this.machineSrc == null || te.isCoreBlock()) {
-            this.machineSrc = new MachineSource(te);
+    @Inject(
+            method = "addBlockEntity",
+            at = @At(value = "NEW", target = "java/lang/IllegalArgumentException"),
+            cancellable = true
+    )
+    private void ufo$allowLargeCoProcessors(CraftingBlockEntity te, CallbackInfo ci) {
+        if (te.getAcceleratorThreads() > 16) {
+            this.accelerator = ufo$getSaturatedThreadSum();
+            ci.cancel();
         }
+    }
 
-        te.setCoreBlock(false);
-        te.saveChanges();
-        this.blockEntities.add(0, te);
+    @Inject(method = "addBlockEntity", at = @At("TAIL"))
+    private void ufo$clampThreadTotal(CraftingBlockEntity te, CallbackInfo ci) {
+        this.accelerator = ufo$getSaturatedThreadSum();
+    }
 
-        if (te instanceof CraftingMonitorBlockEntity monitor) {
-            this.status.add(monitor);
+    private int ufo$getSaturatedThreadSum() {
+        long total = 0L;
+        for (CraftingBlockEntity blockEntity : this.blockEntities) {
+            int threads = blockEntity.getAcceleratorThreads();
+            if (threads > 0) {
+                total += threads;
+                if (total >= Integer.MAX_VALUE) {
+                    return Integer.MAX_VALUE;
+                }
+            }
         }
-
-        long storageBytes = te.getStorageBytes();
-        if (storageBytes > 0) {
-            this.storage += storageBytes;
-        }
-
-        int threads = te.getAcceleratorThreads();
-        if (threads > 0) {
-            long combined = (long) this.accelerator + threads;
-            this.accelerator = (int) Math.min(Integer.MAX_VALUE, combined);
-        }
+        return (int) total;
     }
 }


### PR DESCRIPTION
## Summary
- replace UFO's CraftingCPUCluster overwrite with narrow injects that preserve AE2's original method body
- bypass the hard 16-thread exception without removing the original bytecode shape ExpandedAE redirects into
- recompute and clamp the total accelerator thread count after each block is added to avoid overflow

## Why
ExpandedAE redirects a call inside CraftingCPUCluster.addBlockEntity(). UFO 2.0.0 overwrote that method entirely, which removed ExpandedAE's target and caused a mixin application crash when AE2 initialized crafting CPUs.

## Validation
- ./gradlew compileJava
