### PR TITLE
ci: verify generated resources are up to date before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,16 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Run Data Generation
+        run: ./gradlew runData --stacktrace
+
+      - name: Verify no stale generated resources
+        run: |
+          if ! git diff --quiet src/generated/resources; then
+            echo "ERROR: Generated resources are out of date. Run './gradlew runData' and commit the result."
+            git diff --stat src/generated/resources
+            exit 1
+          fi
+
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,10 @@ jobs:
 
       - name: Verify no stale generated resources
         run: |
-          if ! git diff --quiet src/generated/resources; then
+          status_output="$(git status --porcelain -- src/generated/resources)"
+          if [ -n "$status_output" ]; then
             echo "ERROR: Generated resources are out of date. Run './gradlew runData' and commit the result."
-            git diff --stat src/generated/resources
+            printf '%s\n' "$status_output"
             exit 1
           fi
 


### PR DESCRIPTION
## Context

It was observed that some releases were missing the latest recipes or data. This happens because `src/generated/resources` is versioned in Git. If a developer forgets to run `runData` before committing, or if the CI uses stale files, the resulting build/JAR becomes inconsistent with the actual code.

## Changes

Added a verification step in the CI workflow that:

- Runs `./gradlew runData` to fresh-generate all resources.
- Performs a `git diff` check to compare the newly generated files with the ones committed in the repository.
- Fails the build with an explicit error message if a mismatch is detected.

## Impact

This change ensures that:

- The JAR produced by the CI always contains the most recent data.
- Developers are forced to commit updated resources before their PR can be merged.
- No more "ghost builds" where the code is updated but the recipes remain old.